### PR TITLE
Upload the built compiler as CI release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,10 @@ jobs:
 
       - name: Run negative blackbox tests
         run: opam exec -- make test-blackbox-negative
+
+      - name: Upload compiler artifact
+        if: ${{ matrix.ocaml-compiler == '4.12.x' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: sesterl-${{matrix.os}}
+          path: sesterl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,5 @@ jobs:
         if: ${{ matrix.ocaml-compiler == '4.12.x' }}
         uses: actions/upload-artifact@v2
         with:
-          name: sesterl-${{matrix.os}}
+          name: sesterl-${{ matrix.os }}
           path: sesterl


### PR DESCRIPTION
Hi!

To make it a bit easier for people to try out Sesterl without having to install opam, I am proposing to upload the compiler to GitHub at the end of ocaml 4.12.x CI runs. I think this doesn't cost anything(?). I downloaded the Ubuntu binary and it seems to have worked for me locally.

Not sure if it's a welcome change so feel free to close if not. I don't know if this is a "release" build or how "portable" (compatible with other system versions) the binaries are. Also, maybe this build could also print the shortened git commit SHA and platform somewhere in `sesterl --version` suffix?