### PR TITLE
Change remaining require to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ Also, though not supporting them currently, we want to add features like the fol
   * [x] Compilation using the static interpretation
   * [x] First-class modules
 * [x] Configuration
-  * [x] Loading external modules by `require`
+  * [x] Loading external modules by `import`
   * [x] Package system
   * [x] Embedding external modules as submodules
   * [x] Connection with Rebar3

--- a/test/pass/test_import/import_depended.sest
+++ b/test/pass/test_import/import_depended.sest
@@ -1,4 +1,4 @@
-module RequireDepended = struct
+module ImportDepended = struct
 
   val hello() =
     "Hello"

--- a/test/pass/test_import/import_depending.sest
+++ b/test/pass/test_import/import_depending.sest
@@ -1,0 +1,8 @@
+import ImportDepended
+
+module ImportDepending = struct
+
+  val main(args) =
+    print_debug(ImportDepended.hello())
+
+end

--- a/test/pass/test_import/package.yaml
+++ b/test/pass/test_import/package.yaml
@@ -1,0 +1,5 @@
+package: test_import
+source_directories:
+  - "./"
+
+main_module: "ImportDepending"

--- a/test/pass/test_require/package.yaml
+++ b/test/pass/test_require/package.yaml
@@ -1,5 +1,0 @@
-package: test_require
-source_directories:
-  - "./"
-
-main_module: "RequireDepending"

--- a/test/pass/test_require/require_depending.sest
+++ b/test/pass/test_require/require_depending.sest
@@ -1,8 +1,0 @@
-import RequireDepended
-
-module RequireDepending = struct
-
-  val main(args) =
-    print_debug(RequireDepended.hello())
-
-end


### PR DESCRIPTION
Small cleanup, I noticed `require` got renamed to `import` but there were still a few references to `require` in test file and module names, and one in the readme.