### PR TITLE
Fix non-ascii string/binary literals; Add multi-line binary literals

### DIFF
--- a/src/errors.ml
+++ b/src/errors.ml
@@ -30,6 +30,7 @@ type lexer_error =
   | BlockClosedWithTooManyBackQuotes of Range.t
   | SeeBreakInStringLiteral          of Range.t
   | NotASingleCodePoint              of Range.t
+  | UnknownEscapeSequence            of Range.t
 
 type syntax_error =
   | LexerError of lexer_error

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -212,8 +212,17 @@ rule token = parse
     }
 
   | ("`"+ break) {
+      (* When first character in a string block is a line break,
+         ignore this line break *)
       let posL = Range.from_lexbuf lexbuf in
       let num_start = String.length (Lexing.lexeme lexbuf) - 1 in
+      let strbuf = Buffer.create 128 in
+      string_block num_start posL strbuf lexbuf
+    }
+
+  | ("`"+) {
+      let posL = Range.from_lexbuf lexbuf in
+      let num_start = String.length (Lexing.lexeme lexbuf) in
       let strbuf = Buffer.create 128 in
       string_block num_start posL strbuf lexbuf
     }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -233,6 +233,7 @@ rule token = parse
 and binary_literal posL strbuf = parse
   | break  { raise_error (SeeBreakInStringLiteral(posL)) }
   | eof    { raise_error (SeeEndOfFileInStringLiteral(posL)) }
+  | "\\\\" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\\'; binary_literal posL strbuf lexbuf }
   | "\\\"" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '"'; binary_literal posL strbuf lexbuf }
   | "\""   { let posR = Range.from_lexbuf lexbuf in (Range.unite posL posR, Buffer.contents strbuf) }
   | _ as c { Buffer.add_char strbuf c; binary_literal posL strbuf lexbuf }
@@ -240,6 +241,7 @@ and binary_literal posL strbuf = parse
 and string_literal posL strbuf = parse
   | break  { raise_error (SeeBreakInStringLiteral(posL)) }
   | eof    { raise_error (SeeEndOfFileInStringLiteral(posL)) }
+  | "\\\\" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\\'; binary_literal posL strbuf lexbuf }
   | "\\\'" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\''; string_literal posL strbuf lexbuf }
   | "\\\"" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\"'; string_literal posL strbuf lexbuf }
   | "\""   { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\"'; string_literal posL strbuf lexbuf }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -214,6 +214,7 @@ rule token = parse
   | ("`"+ break) {
       (* When first character in a string block is a line break,
          ignore this line break *)
+      Lexing.new_line lexbuf;
       let posL = Range.from_lexbuf lexbuf in
       let num_start = String.length (Lexing.lexeme lexbuf) - 1 in
       let strbuf = Buffer.create 128 in

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -216,7 +216,7 @@ rule token = parse
          ignore this line break *)
       Lexing.new_line lexbuf;
       let posL = Range.from_lexbuf lexbuf in
-      let num_start = String.length (Lexing.lexeme lexbuf) - 1 in
+      let num_start = String.length (String.trim (Lexing.lexeme lexbuf)) in
       let strbuf = Buffer.create 128 in
       string_block num_start posL strbuf lexbuf
     }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -199,8 +199,6 @@ rule token = parse
       let posL = Range.from_lexbuf lexbuf in
       let strbuf = Buffer.create 128 in
       let (rng, s) = binary_literal posL strbuf lexbuf in
-      (* TODO: handle multi-codepoint unicode characters e.g. 🤷🏽‍♀️
-         (raise_error NotASingleCodePoint or convert somehow) *)
       BINARY(rng, s)
     }
 
@@ -208,6 +206,8 @@ rule token = parse
       let posL = Range.from_lexbuf lexbuf in
       let strbuf = Buffer.create 128 in
       let (rng, s) = string_literal posL strbuf lexbuf in
+      (* TODO: handle multi-codepoint unicode characters e.g. 🤷🏽‍♀️
+         (raise_error NotASingleCodePoint or convert somehow) *)
       STRING(rng, s)
     }
 

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -247,7 +247,7 @@ and string_literal posL strbuf = parse
   | break  { raise_error (SeeBreakInStringLiteral(posL)) }
   | eof    { raise_error (SeeEndOfFileInStringLiteral(posL)) }
   | ("\\" (_ as c)) {
-      Buffer.add_char strbuf (escape_sequence c posL); binary_literal posL strbuf lexbuf
+      Buffer.add_char strbuf (escape_sequence c posL); string_literal posL strbuf lexbuf
     }
   | "\'"   { let posR = Range.from_lexbuf lexbuf in (Range.unite posL posR, Buffer.contents strbuf) }
   | _ as c { Buffer.add_char strbuf c; string_literal posL strbuf lexbuf }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -240,6 +240,7 @@ and string_literal posL strbuf = parse
   | break  { raise_error (SeeBreakInStringLiteral(posL)) }
   | eof    { raise_error (SeeEndOfFileInStringLiteral(posL)) }
   | "\\\'" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\''; string_literal posL strbuf lexbuf }
+  | "\\\"" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\"'; string_literal posL strbuf lexbuf }
   | "\""   { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\"'; string_literal posL strbuf lexbuf }
   | "\'"   { let posR = Range.from_lexbuf lexbuf in (Range.unite posL posR, Buffer.contents strbuf) }
   | _ as c { Buffer.add_char strbuf c; string_literal posL strbuf lexbuf }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -207,9 +207,9 @@ rule token = parse
       STRING(rng, s)
     }
 
-  | ("`" +) {
+  | ("`"+ break) {
       let posL = Range.from_lexbuf lexbuf in
-      let num_start = String.length (Lexing.lexeme lexbuf) in
+      let num_start = String.length (Lexing.lexeme lexbuf) - 1 in
       let strbuf = Buffer.create 128 in
       string_block num_start posL strbuf lexbuf
     }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -233,8 +233,6 @@ and binary_literal posL strbuf = parse
   | break  { raise_error (SeeBreakInStringLiteral(posL)) }
   | eof    { raise_error (SeeEndOfFileInStringLiteral(posL)) }
   | "\\\"" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '"'; binary_literal posL strbuf lexbuf }
-  (* TODO: move this single quote escaping to outputErlangCode.ml ? *)
-  | "\'"   { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\''; binary_literal posL strbuf lexbuf }
   | "\""   { let posR = Range.from_lexbuf lexbuf in (Range.unite posL posR, Buffer.contents strbuf) }
   | _ as c { Buffer.add_char strbuf c; binary_literal posL strbuf lexbuf }
 
@@ -242,7 +240,6 @@ and string_literal posL strbuf = parse
   | break  { raise_error (SeeBreakInStringLiteral(posL)) }
   | eof    { raise_error (SeeEndOfFileInStringLiteral(posL)) }
   | "\\\'" { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\''; string_literal posL strbuf lexbuf }
-  (* TODO: move this double quote escaping to outputErlangCode.ml ? *)
   | "\""   { Buffer.add_char strbuf '\\'; Buffer.add_char strbuf '\"'; string_literal posL strbuf lexbuf }
   | "\'"   { let posR = Range.from_lexbuf lexbuf in (Range.unite posL posR, Buffer.contents strbuf) }
   | _ as c { Buffer.add_char strbuf c; string_literal posL strbuf lexbuf }

--- a/src/logging.ml
+++ b/src/logging.ml
@@ -76,6 +76,10 @@ let report_lexer_error (e : lexer_error) : unit =
       Format.printf "%a: not a single code point\n"
         Range.pp rng
 
+  | UnknownEscapeSequence(rngL) ->
+      Format.printf "%a: unknown escape sequence \n"
+        Range.pp rngL
+
 
 let report_config_error (e : config_error) : unit =
   Format.printf "! [Build error] ";

--- a/src/outputErlangCode.ml
+++ b/src/outputErlangCode.ml
@@ -151,6 +151,9 @@ let stringify_format_element = function
       in
       (1, Printf.sprintf "~%s%s" s ch)
 
+let escape_string s =
+  (* TODO *)
+  s
 
 let stringify_base_constant (bc : base_constant) =
   match bc with
@@ -167,9 +170,9 @@ let stringify_base_constant (bc : base_constant) =
       else
         assert false
 
-  | BinaryByString(s) -> Printf.sprintf "<<\"%s\"/utf8>>" s
+  | BinaryByString(s) -> Printf.sprintf "<<\"%s\"/utf8>>" (escape_string s)
   | BinaryByInts(ns)  -> Printf.sprintf "<<%s>>" (ns |> List.map string_of_int |> String.concat ", ")
-  | String(s)         -> Printf.sprintf "\"%s\"" s
+  | String(s)         -> Printf.sprintf "\"%s\"" (escape_string s)
   | Char(uchar)       -> Printf.sprintf "%d" (Uchar.to_int uchar)
 
   | FormatString(fmtelems) ->

--- a/src/outputErlangCode.ml
+++ b/src/outputErlangCode.ml
@@ -151,9 +151,21 @@ let stringify_format_element = function
       in
       (1, Printf.sprintf "~%s%s" s ch)
 
+let escape_character c =
+  match Uchar.to_int c with
+  | 10 -> [ Uchar.of_char '\\'; Uchar.of_char 'n' ]
+  | 13 -> [ Uchar.of_char '\\'; Uchar.of_char '\r' ]
+  | 9  -> [ Uchar.of_char '\\'; Uchar.of_char '\t' ]
+  | 92 -> [ Uchar.of_char '\\'; Uchar.of_char '\\' ]
+  | 34 -> [ Uchar.of_char '\\'; Uchar.of_char '"' ]
+  | 39 -> [ Uchar.of_char '\\'; Uchar.of_char '\'' ]
+  | _ -> [c]
+
 let escape_string s =
-  (* TODO *)
-  s
+  let escaped =
+    s |> MyUtil.Utf.uchar_of_utf8 |> List.map escape_character |> List.flatten
+  in
+  String.concat "" escaped (* TODO this doesnt' compile, how to fix this? *)
 
 let stringify_base_constant (bc : base_constant) =
   match bc with

--- a/src/outputErlangCode.ml
+++ b/src/outputErlangCode.ml
@@ -154,8 +154,8 @@ let stringify_format_element = function
 let escape_character c =
   match Uchar.to_int c with
   | 10 -> [ Uchar.of_char '\\'; Uchar.of_char 'n' ]
-  | 13 -> [ Uchar.of_char '\\'; Uchar.of_char '\r' ]
-  | 9  -> [ Uchar.of_char '\\'; Uchar.of_char '\t' ]
+  | 13 -> [ Uchar.of_char '\\'; Uchar.of_char 'r' ]
+  | 9  -> [ Uchar.of_char '\\'; Uchar.of_char 't' ]
   | 92 -> [ Uchar.of_char '\\'; Uchar.of_char '\\' ]
   | 34 -> [ Uchar.of_char '\\'; Uchar.of_char '"' ]
   | 39 -> [ Uchar.of_char '\\'; Uchar.of_char '\'' ]

--- a/src/outputErlangCode.ml
+++ b/src/outputErlangCode.ml
@@ -162,10 +162,9 @@ let escape_character c =
   | _ -> [c]
 
 let escape_string s =
-  let escaped =
-    s |> MyUtil.Utf.uchar_of_utf8 |> List.map escape_character |> List.flatten
-  in
-  String.concat "" escaped (* TODO this doesnt' compile, how to fix this? *)
+  let buffer = Buffer.create 0 in
+  s |> MyUtil.Utf.uchar_of_utf8 |> List.map escape_character |> List.flatten |> List.iter (Buffer.add_utf_8_uchar buffer);
+  Buffer.contents buffer
 
 let stringify_base_constant (bc : base_constant) =
   match bc with

--- a/src/outputErlangCode.ml
+++ b/src/outputErlangCode.ml
@@ -167,9 +167,9 @@ let stringify_base_constant (bc : base_constant) =
       else
         assert false
 
-  | BinaryByString(s) -> Printf.sprintf "<<\"%s\">>" (String.escaped s)
+  | BinaryByString(s) -> Printf.sprintf "<<\"%s\"/utf8>>" s
   | BinaryByInts(ns)  -> Printf.sprintf "<<%s>>" (ns |> List.map string_of_int |> String.concat ", ")
-  | String(s)         -> Printf.sprintf "\"%s\"" (String.escaped s)
+  | String(s)         -> Printf.sprintf "\"%s\"" s
   | Char(uchar)       -> Printf.sprintf "%d" (Uchar.to_int uchar)
 
   | FormatString(fmtelems) ->

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -683,7 +683,7 @@ exprbot:
     }
   | strblock=STRING_BLOCK {
       let (rng, s) = strblock in
-      (rng, BaseConst(BinaryByString(s)))
+      (rng, BaseConst(BinaryByInts(s |> String.to_seq |> List.of_seq |> List.map Char.code)))
   }
   | strlit=STRING {
       let (rng, s) = strlit in

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -683,7 +683,7 @@ exprbot:
     }
   | strblock=STRING_BLOCK {
       let (rng, s) = strblock in
-      (rng, BaseConst(String(s)))
+      (rng, BaseConst(BinaryByString(s)))
   }
   | strlit=STRING {
       let (rng, s) = strlit in

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -677,10 +677,14 @@ exprbot:
       let rng = make_range (Token(tokL)) (Token(tokR)) in
       (rng, BinaryByList(ns))
     }
-  | strlit=BINARY {
-      let (rng, s) = strlit in
+  | binlit=BINARY {
+      let (rng, s) = binlit in
       (rng, BaseConst(BinaryByString(s)))
     }
+  | strblock=STRING_BLOCK {
+      let (rng, s) = strblock in
+      (rng, BaseConst(String(s)))
+  }
   | strlit=STRING {
       let (rng, s) = strlit in
       (rng, BaseConst(String(s)))

--- a/test/pass/test_binary.sest
+++ b/test/pass/test_binary.sest
@@ -1,0 +1,22 @@
+module TestBinary = struct
+
+  val check : fun({binary, binary, binary, binary}) -> fun(binary, int) -> unit = external 1 ```
+    check(X) ->
+        fun(FileName, LineNumber) ->
+            {<<240,159,145,169,226,128,141,240,159,148,172>>,<<"\n">>,<<"!`\\\\">>,<<"one\ntwo">>} = X,
+            ok
+        end.
+    ```
+
+  val main(args) =
+    let woman_scientist = "👩‍🔬" in
+    let newline = "\n" in
+    let raw = ``!`\\`` in
+    let multiline = ```
+one
+two```
+    in
+    let result = {woman_scientist, newline, raw, multiline} in
+    print_debug(assert check({woman_scientist, newline, raw, multiline}))
+
+end

--- a/test/pass/test_binary.sest
+++ b/test/pass/test_binary.sest
@@ -1,20 +1,27 @@
 module TestBinary = struct
 
   val check : fun({binary, binary, binary, binary}) -> {binary, binary, binary, binary} = external 1 ```
-    check(X) ->
-        {<<"👩‍🔬"/utf8>>,<<"\n"/utf8>>,<<33, 96, 92, 92>>,<<111, 110, 101, 10, 116, 119, 111>>} = X,
-        X.
+    check({A, B, C, D}) ->
+      <<240,159,145,169,226,128,141,240,159,148,172>> = A,
+      <<"👩‍🔬"/utf8>> = A,
+      <<8,127,27,12,10,13,32,9,11,88,65,194,170,10,1,1,39,34,92>> = B,
+      <<"\b\d\e\f\n\r\s\t\v\XA\xAA\x{A}\^a\^A\'\"\\"/utf8>> = B,
+      <<33,34,39,96,92,92>> = C,
+      <<"!\"\'`\\\\"/utf8>> = C,
+      <<111,110,101,10,116,119,111>> = D,
+      <<"one\ntwo"/utf8>> = D,
+      {A, B, C, D}.
     ```
 
   val main(args) =
     let woman_scientist = "👩‍🔬" in
-    let newline = "\n" in
-    let raw = ``!`\\`` in
+    let escape_sequences = "\b\d\e\f\n\r\s\t\v\XA\xAA\x{A}\^a\^A\'\"\\" in
+    let raw = ``!"'`\\`` in
     let multiline = ```
 one
 two```
     in
-    let result = {woman_scientist, newline, raw, multiline} in
-    print_debug(check({woman_scientist, newline, raw, multiline}))
+    let examples = {woman_scientist, escape_sequences, raw, multiline} in
+    print_debug(check(examples))
 
 end

--- a/test/pass/test_binary.sest
+++ b/test/pass/test_binary.sest
@@ -1,27 +1,30 @@
 module TestBinary = struct
 
-  val check : fun({binary, binary, binary, binary}) -> {binary, binary, binary, binary} = external 1 ```
-    check({A, B, C, D}) ->
+  val check : fun({binary, binary, binary, binary, binary}) -> {binary, binary, binary, binary, binary} = external 1 ```
+    check({A, B, C, D, E}) ->
       <<240,159,145,169,226,128,141,240,159,148,172>> = A,
       <<"👩‍🔬"/utf8>> = A,
-      <<8,127,27,12,10,13,32,9,11,88,65,194,170,10,1,1,39,34,92>> = B,
-      <<"\b\d\e\f\n\r\s\t\v\XA\xAA\x{A}\^a\^A\'\"\\"/utf8>> = B,
-      <<33,34,39,96,92,92>> = C,
-      <<"!\"\'`\\\\"/utf8>> = C,
-      <<111,110,101,10,116,119,111>> = D,
-      <<"one\ntwo"/utf8>> = D,
-      {A, B, C, D}.
+      <<10,13,9,34,39,92>> = B,
+      <<"\n\r\t\"\'\\"/utf8>> = B,
+      <<39>> = C,
+      <<"\'"/utf8>> = C,
+      <<33,34,39,96,92,92>> = D,
+      <<"!\"\'`\\\\"/utf8>> = D,
+      <<111,110,101,10,116,119,111>> = E,
+      <<"one\ntwo"/utf8>> = E,
+      {A, B, C, D, E}.
     ```
 
   val main(args) =
     let woman_scientist = "👩‍🔬" in
-    let escape_sequences = "\b\d\e\f\n\r\s\t\v\XA\xAA\x{A}\^a\^A\'\"\\" in
+    let escape_sequences = "\n\r\t\"\'\\" in
+    let single_quote = "'" in
     let raw = ``!"'`\\`` in
     let multiline = ```
 one
 two```
     in
-    let examples = {woman_scientist, escape_sequences, raw, multiline} in
+    let examples = {woman_scientist, escape_sequences, single_quote, raw, multiline} in
     print_debug(check(examples))
 
 end

--- a/test/pass/test_binary.sest
+++ b/test/pass/test_binary.sest
@@ -1,11 +1,9 @@
 module TestBinary = struct
 
-  val check : fun({binary, binary, binary, binary}) -> fun(binary, int) -> unit = external 1 ```
+  val check : fun({binary, binary, binary, binary}) -> {binary, binary, binary, binary} = external 1 ```
     check(X) ->
-        fun(FileName, LineNumber) ->
-            {<<"👩‍🔬"/utf8>>,<<"\n"/utf8>>,<<33, 96, 92, 92>>,<<111, 110, 101, 10, 116, 119, 111>>} = X,
-            ok
-        end.
+        {<<"👩‍🔬"/utf8>>,<<"\n"/utf8>>,<<33, 96, 92, 92>>,<<111, 110, 101, 10, 116, 119, 111>>} = X,
+        X.
     ```
 
   val main(args) =
@@ -17,6 +15,6 @@ one
 two```
     in
     let result = {woman_scientist, newline, raw, multiline} in
-    print_debug(assert check({woman_scientist, newline, raw, multiline}))
+    print_debug(check({woman_scientist, newline, raw, multiline}))
 
 end

--- a/test/pass/test_binary.sest
+++ b/test/pass/test_binary.sest
@@ -3,7 +3,7 @@ module TestBinary = struct
   val check : fun({binary, binary, binary, binary}) -> fun(binary, int) -> unit = external 1 ```
     check(X) ->
         fun(FileName, LineNumber) ->
-            {<<240,159,145,169,226,128,141,240,159,148,172>>,<<"\n">>,<<"!`\\\\">>,<<"one\ntwo">>} = X,
+            {<<"👩‍🔬"/utf8>>,<<"\n"/utf8>>,<<33, 96, 92, 92>>,<<111, 110, 101, 10, 116, 119, 111>>} = X,
             ok
         end.
     ```


### PR DESCRIPTION
Also: require (and ignore) one newline at the start of a string block edit: This change is to have first line aligned horizontally with other lines when you don't want a newline at the start.