### PR TITLE
Remove floating-point-number-related primitives

### DIFF
--- a/src/primitives.ml
+++ b/src/primitives.ml
@@ -216,39 +216,6 @@ let primitive_definitions = [
     };
   };
   {
-    source = Some{
-      identifier = "float";
-      typ        = [i] @-> f;
-    };
-    target = {
-      target_name = "float";
-      parameters  = ["N"];
-      code        = "N";
-    };
-  };
-  {
-    source = Some{
-      identifier = "round";
-      typ        = [f] @-> i;
-    };
-    target = {
-      target_name = "round";
-      parameters  = ["X"];
-      code        = "erlang:round(X)";
-    };
-  };
-  {
-    source = Some{
-      identifier = "truncate";
-      typ        = [f] @-> i;
-    };
-    target = {
-      target_name = "truncate";
-      parameters  = ["X"];
-      code        = "erlang:trunc(X)";
-    };
-  };
-  {
     source = None;
     target = {
       target_name = decode_option_function;

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -464,5 +464,3 @@ module TypeNameMap = Map.Make(String)
 module ModuleNameMap = Map.Make(String)
 
 module SignatureNameMap = Map.Make(String)
-
-module ModuleNameSet = Set.Make(String)

--- a/test/pass/test_float.sest
+++ b/test/pass/test_float.sest
@@ -3,7 +3,6 @@ module TestFloat = struct
   val add(x, y) = x +. y
 
   val main(_) =
-    let res = add(42.57, 1.) in
-    print_debug({res, round(res), truncate(res)})
+    print_debug(add(42.57, 1.))
 
 end


### PR DESCRIPTION
Floating-point-number-related primitives will migrate to 'Stdlib.Float'.