### PR TITLE
Stop using dune cache when `macos-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          dune-cache: true
+          dune-cache: ${{ matrix.os != 'macos-latest' }}
           opam-depext-flags: --with-test
 
       - name: Setup Erlang


### PR DESCRIPTION
- It's copy from https://github.com/gfngfn/SATySFi/blob/8a1b1fbefae9c6958d06ee64218619e00ef0afc7/.github/workflows/ci.yml#L38
- I think it maybe solve to randomly failing CI in `macos-latest` 🤔 