### PR TITLE
Make comparison operators polymorphic; Add != operator

### DIFF
--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -178,6 +178,8 @@ rule token = parse
   | "="               { DEFEQ(Range.from_lexbuf lexbuf) }
   | ("=" (nssymbol+)) { BINOP_EQ(Range.from_lexbuf lexbuf, Lexing.lexeme lexbuf) }
 
+  | "!="              { BINOP_NEQ(Range.from_lexbuf lexbuf, Lexing.lexeme lexbuf) }
+
   | "<-"              { REVARROW(Range.from_lexbuf lexbuf) }
   | "<<"              { LTLT(Range.from_lexbuf lexbuf) }
   | "<"               { LT_EXACT(Range.from_lexbuf lexbuf) }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -100,7 +100,7 @@
 %token<Range.t> DEFEQ COMMA ARROW REVARROW BAR UNDERSCORE CONS COLON COERCE
 %token<Range.t> GT_SPACES GT_NOSPACE LTLT LT_EXACT
 %token<Range.t * string> LOWER DOTLOWER UPPER DOTUPPER TYPARAM ROWPARAM MNDLABEL OPTLABEL
-%token<Range.t * string> BINOP_TIMES BINOP_DIVIDES BINOP_PLUS BINOP_MINUS BINOP_AMP BINOP_BAR BINOP_EQ BINOP_LT BINOP_GT
+%token<Range.t * string> BINOP_TIMES BINOP_DIVIDES BINOP_PLUS BINOP_MINUS BINOP_AMP BINOP_BAR BINOP_EQ BINOP_NEQ BINOP_LT BINOP_GT
 %token<Range.t * int> INT
 %token<Range.t * float> FLOAT
 %token<Range.t * string> BINARY STRING STRING_BLOCK
@@ -544,6 +544,7 @@ exprlor:
 ;
 exprcomp:
   | e1=exprcons; op=BINOP_EQ; e2=exprcomp { binary e1 op e2 }
+  | e1=exprcons; op=BINOP_NEQ;e2=exprcomp { binary e1 op e2 }
   | e1=exprcons; op=oplt;     e2=exprcomp { binary e1 op e2 }
   | e1=exprcons; op=opgt;     e2=exprcomp { binary e1 op e2 }
   | e=exprcons                            { e }

--- a/src/primitives.ml
+++ b/src/primitives.ml
@@ -376,8 +376,8 @@ let initial_environment =
     |> add_operators [
       ("&&", tylogic, "and");
       ("||", tylogic, "or" );
-      ("==", tycomp , "==" );
-      ("!=", tycomp , "/=" );
+      ("==", tycomp , "=:=" );
+      ("!=", tycomp , "=/=" );
       ("<=", tycomp , "=<" );
       (">=", tycomp , ">=" );
       ("<" , tycomp , "<"  );

--- a/src/primitives.ml
+++ b/src/primitives.ml
@@ -98,7 +98,9 @@ let eff tydoms tyrcv ty0 =
 let pid tyrcv = (dr, PidType(Pid(tyrcv)))
 
 let tylogic : poly_type = [b; b] @-> b
-let tycomp  : poly_type = [i; i] @-> b
+let tycomp  : poly_type =
+  let typaram = fresh_bound () in
+  [typaram; typaram] @-> b
 let tyarith : poly_type = [i; i] @-> i
 let tyarith_float : poly_type = [f; f] @-> f
 
@@ -375,6 +377,7 @@ let initial_environment =
       ("&&", tylogic, "and");
       ("||", tylogic, "or" );
       ("==", tycomp , "==" );
+      ("!=", tycomp , "/=" );
       ("<=", tycomp , "=<" );
       (">=", tycomp , ">=" );
       ("<" , tycomp , "<"  );


### PR DESCRIPTION
closes #60 

I think this should do it? In Erlang the operators should work on any type. In fact it could be even `'a, 'b -> bool` but I don't think this is leveraged often and with `'a 'a` user will see at compile time that they are trying something unusual.

I can add a test file if you want