### PR TITLE
Add workflows to create a release PR and draft a release with artifacts

### DIFF
--- a/.github/workflows/prepare-new-release-pr.yml
+++ b/.github/workflows/prepare-new-release-pr.yml
@@ -1,0 +1,67 @@
+# Based on https://github.com/thomaseizinger/github-action-gitflow-release-workflow
+
+name: "Prepare new release PR"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version you want to release. (e.g. "0.0.1")'
+        required: true
+
+jobs:
+  prepare-new-release-pr:
+    name: Prepare a new release PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Update changelog
+        uses: thomaseizinger/keep-a-changelog-new-release@1.3.0
+        with:
+          tag: v${{ github.event.inputs.version }}
+
+      - name: Initialize mandatory git config
+        run: |
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --local user.name "$GITHUB_ACTOR"
+
+      - name: Bump version
+        run: |
+          LAST_TAG_REV=$(git rev-list --tags --max-count=1)
+          PREVIOUS_VERSION=$(git describe --tags "$LAST_TAG_REV"  | sed 's/v//')
+          echo "$PREVIOUS_VERSION"
+          NEW_VERSION="${{ github.event.inputs.version }}"
+          echo "$NEW_VERSION"
+          sed -i "0,/$PREVIOUS_VERSION/s//$NEW_VERSION/" dune-project
+          sed -i "0,/$PREVIOUS_VERSION/s//$NEW_VERSION/" sesterl.opam
+          sed -i "0,/$PREVIOUS_VERSION/s//$NEW_VERSION/" src/constants.ml
+
+      - name: Commit changelog and manifest files
+        id: make-commit
+        run: |
+          git add CHANGELOG.md dune-project sesterl.opam src/constants.ml
+          git commit --message "Prepare release v${{ github.event.inputs.version }}"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+
+      - name: Push new branch
+        run: git push origin release/${{ github.event.inputs.version }}
+
+      - name: Create pull request
+        uses: thomaseizinger/create-pull-request@1.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: master
+          title: Release v${{ github.event.inputs.version }}
+          reviewers: ${{ github.actor }}
+          body: |
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.
+            Merging this PR will trigger a workflow to create git tag, a GitHub release and upload any assets that are created as part of the release build.

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -1,0 +1,83 @@
+# Based on https://github.com/thomaseizinger/github-action-gitflow-release-workflow
+
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+      release_version: ${{ steps.extract-version.outputs.release_version }}
+    steps:
+      - name: Extract version from branch name (for release branches)
+        id: extract-version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          RELEASE_VERSION=${BRANCH_NAME#release/}
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "::set-output name=release_version::$RELEASE_VERSION"
+      - name: Create Release
+        id: release
+        uses: thomaseizinger/create-release@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          tag_name: v${{ env.RELEASE_VERSION }}
+          name: Sesterl v${{ env.RELEASE_VERSION }}
+          draft: true
+          prerelease: false
+
+  build-upload-release-artifacts:
+    name: Build and upload release artifacts
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.13.x
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: ${{ matrix.os != 'macos-latest' }}
+
+      - name: Install opam packages
+        run: opam install . --deps-only
+
+      - name: Build Sesterl
+        run: |
+          VERSION_DASHES=$(echo "${{ needs.create-release.outputs.release_version }}" | sed 's/\./-/g')
+          ASSET="sesterl-$VERSION_DASHES-${{ matrix.os }}.zip"
+          echo "ASSET=$ASSET" >> $GITHUB_ENV
+          opam exec -- make all
+          zip "$ASSET" sesterl
+
+      - name: Upload to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET }}
+          asset_name: ${{ env.ASSET }}
+          asset_content_type: application/gzip


### PR DESCRIPTION
How to use:
1. After this is merged, when preparing a new release go to Actions -> Prepare new release PR -> Run workflow -> Enter new version -> Run workflow (see screenshot below)
![image](https://user-images.githubusercontent.com/4972756/145897288-f4c31639-7f70-45f7-bb2e-1bb9e5defa35.png)
This will create a pull request similar to https://github.com/michallepicki/Sesterl/pull/6 (the first one will show a bit more changes to the `CHANGELOG.md` file because the "keep-a-changelog-new-release" action is a bit opinionated about the markdown file formatting)
2. After merging that pull request, a "Publish new release" action will run and
- create a draft release visible on the [Releases page](https://github.com/michallepicki/Sesterl/releases) only for those with write access
- build artifacts for Ubuntu and MacOS, and when done building, upload them to that draft release
3. After a few minutes when the release has both assets attached (sometimes it can take longer if there were many builds running recently, e.g. because of hitting MacOS runners concurrency limits) the Draft release can be edited and published with the automatically created artifacts from there. [Example release](https://github.com/michallepicki/Sesterl/releases/tag/v0.2.2) created this way.

Possible improvements:
- Integrate with `CI` workflow to reduce duplicated builds waste work, to re-use artifacts from builds attached to the `CI` workflow results (I'm not sure how to do that reliably. I used a separate workflow and PR merge event + checking branch name prefix because it seems like a good trigger)
- Include link to the changelog (on that commit, or on master but pointing to specific heading through URL hash) - easier, or copy that release's changelog text into the prepared release draft - a bit harder
- Add a windows target (if there will be someone that wants to use it...)

Alternative solutions:
- It could create a full-blown release up-front instead of a draft. Then the build jobs would still be able to push to that release afterwards (I tested it and it worked). I decided not to do that, so that when a release will be created, it will already have binaries attached when someone gets a notification about it and opens it).
- If you prefer "less", the action to prepare a PR could be removed. Then, the action to prepare a release and upload build artifacts to it could be triggered by pushing a tag instead. Or workflow dispatch input/button.